### PR TITLE
Add notice: one bug per issue (related bugs allowed)

### DIFF
--- a/.github/ISSUE_TEMPLATE/world-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/world-bug-report.md
@@ -1,11 +1,11 @@
----
 name: World Bug Report
 about: Create a World Bug Report
 title: ''
 labels: bug, World
 assignees: ''
 
----
+
+> Note: Please report one bug per issue when possible. Multiple bugs are okay if they are closely related (e.g., all tables in the cafe are floating). Submitting many unrelated bugs in a single report makes tracking and fixing them more difficult.
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
This PR updates the world bug report template to include a clear notice encouraging one bug per issue to improve triage and tracking. Related bugs can be grouped when they share the same root cause (e.g., all tables in the cafe are floating).

Changes:
- Added a prominent Markdown blockquote notice above "Describe the bug".
- Rationale: helps world developers track and fix issues individually.

File:
- .github/ISSUE_TEMPLATE/world-bug-report.md